### PR TITLE
Add .babelrc to ignorefiles

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+.babelrc

--- a/.yarnignore
+++ b/.yarnignore
@@ -1,0 +1,1 @@
+.babelrc

--- a/lib/render.js
+++ b/lib/render.js
@@ -54,5 +54,6 @@ export default async function render (asset, options) {
 }
 
 const throwError = (error) => {
+  console.error(error)
   throw new Error(error)
 }


### PR DESCRIPTION
Noticed that `.babelrc` was being picked up through symlinks which made me realize that it shouldn't be sent out when published. 