### PR TITLE
Stylesheet reset fix

### DIFF
--- a/dist/componentRenderer.js
+++ b/dist/componentRenderer.js
@@ -25,9 +25,6 @@ var _lodash = require("lodash");
 
 var _styledComponents = require("styled-components");
 
-// For Jest. See: https://github.com/styled-components/styled-components/issues/1692
-var StyleSheet = _styledComponents.__DO_NOT_USE_OR_YOU_WILL_BE_HAUNTED_BY_SPOOKY_GHOSTS.StyleSheet;
-StyleSheet.reset(true);
 var modes = {
   CLIENT: 'client',
   SERVER: 'server'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artsy/stitch",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Helps your Component and Template dependencies peacefully coexist",
   "main": "./dist/index.js",
   "repository": "git@github.com:artsy/stitch.git",

--- a/src/__tests__/componentRenderer.test.js
+++ b/src/__tests__/componentRenderer.test.js
@@ -1,5 +1,7 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled, {
+  __DO_NOT_USE_OR_YOU_WILL_BE_HAUNTED_BY_SPOOKY_GHOSTS
+} from 'styled-components'
 import { componentRenderer } from '../componentRenderer'
 import { uniq } from 'lodash'
 
@@ -11,6 +13,13 @@ const modules = {
 
 describe('componentRenderer', () => {
   describe('server-side', () => {
+    beforeEach(() => {
+      // For Jest. See: https://github.com/styled-components/styled-components/issues/1692
+      const {
+        StyleSheet
+      } = __DO_NOT_USE_OR_YOU_WILL_BE_HAUNTED_BY_SPOOKY_GHOSTS
+      StyleSheet.reset(true)
+    })
     it('returns mapped components', () => {
       const { components } = componentRenderer({
         mode: 'server',

--- a/src/componentRenderer.js
+++ b/src/componentRenderer.js
@@ -8,10 +8,6 @@ import {
   __DO_NOT_USE_OR_YOU_WILL_BE_HAUNTED_BY_SPOOKY_GHOSTS
 } from 'styled-components'
 
-// For Jest. See: https://github.com/styled-components/styled-components/issues/1692
-const { StyleSheet } = __DO_NOT_USE_OR_YOU_WILL_BE_HAUNTED_BY_SPOOKY_GHOSTS
-StyleSheet.reset(true)
-
 const modes = {
   CLIENT: 'client',
   SERVER: 'server'


### PR DESCRIPTION
This is PR fixes an issue with styles not being injected due to`StyleSheet.reset()` causes `styled-components` to flush all the styles it generated for components that render client-side.


E.g.:
![screen shot 2018-04-26 at 8 50 40 am](https://user-images.githubusercontent.com/296775/39321289-9c310078-4954-11e8-8974-500a930f6949.png)

