### PR TITLE
[Feature] Add ability to pass custom mountIds on server

### DIFF
--- a/dist/componentRenderer.js
+++ b/dist/componentRenderer.js
@@ -40,13 +40,15 @@ function componentRenderer(config) {
   } : _config$serialize;
   var components = (0, _keys.default)(modules).reduce(function (moduleMap, moduleName) {
     var Component = modules[moduleName];
-    return (0, _objectSpread3.default)({}, moduleMap, (0, _defineProperty2.default)({}, moduleName, function (props) {
+    return (0, _objectSpread3.default)({}, moduleMap, (0, _defineProperty2.default)({}, moduleName, function () {
+      var props = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+
       if (mode === modes.SERVER) {
-        var mountId = (0, _lodash.uniqueId)('stitch-component-');
+        var mountId = props.mountId || (0, _lodash.uniqueId)('stitch-component-');
         var sheet = new _styledComponents.ServerStyleSheet();
         var html = (0, _server.renderToString)(sheet.collectStyles(_react.default.createElement(Component, props)));
         var css = sheet.getStyleTags();
-        var markup = "\n            <div id=".concat(mountId, ">\n              ").concat(css, "\n              ").concat(html, "\n            </div>\n          ").trim();
+        var markup = "\n            <div id=\"".concat(mountId, "\">\n              ").concat(css, "\n              ").concat(html, "\n            </div>\n          ").trim();
         serialize({
           mountId: mountId,
           moduleName: moduleName,

--- a/src/__tests__/componentRenderer.test.js
+++ b/src/__tests__/componentRenderer.test.js
@@ -46,7 +46,20 @@ describe('componentRenderer', () => {
         modules
       })
 
-      expect(components.Foo()).toContain('id=stitch-component-')
+      expect(components.Foo()).toContain('id="stitch-component-')
+    })
+
+    it('injects custom DOM id mount points', () => {
+      const { components } = componentRenderer({
+        mode: 'server',
+        modules
+      })
+
+      expect(
+        components.Foo({
+          mountId: 'myCustomMountId'
+        })
+      ).toContain('id="myCustomMountId"')
     })
 
     it('renders component css', () => {

--- a/src/componentRenderer.js
+++ b/src/componentRenderer.js
@@ -22,16 +22,16 @@ export function componentRenderer(config) {
     return {
       ...moduleMap,
 
-      [moduleName]: props => {
+      [moduleName]: (props = {}) => {
         if (mode === modes.SERVER) {
-          const mountId = uniqueId('stitch-component-')
+          const mountId = props.mountId || uniqueId('stitch-component-')
           const sheet = new ServerStyleSheet()
           const html = renderToString(
             sheet.collectStyles(<Component {...props} />)
           )
           const css = sheet.getStyleTags()
           const markup = `
-            <div id=${mountId}>
+            <div id="${mountId}">
               ${css}
               ${html}
             </div>


### PR DESCRIPTION
Previously `mountId` as a passed prop would only respect client-side renders 