### PR TITLE
Remove deprecated API `renderLayout` in favor of `stitch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ In its most basic form, this library is a single function that accepts a path to
 ```
 
 ```js
-const html = await renderLayout({
+const html = await stitch({
   layout: "templates/layout.handlebars",
   data: {
     title: "Hello!",
@@ -94,7 +94,7 @@ By adding "blocks" you can begin assembling more complex layouts. Blocks represe
 ```js
 // index.js
 
-const html = await renderLayout({
+const html = await stitch({
   layout: "templates/layout.handlebars",
   data: {
     title: "Hello World!",
@@ -133,7 +133,7 @@ You can add as many blocks as you need, which are accessible by key. Each block 
 // index.js
 
 import express from "express"
-import { renderLayout } from "@artsy/stitch"
+import { stitch } from "@artsy/stitch"
 
 import Body from "./components/Body"
 import Footer from "./components/Footer"
@@ -142,7 +142,7 @@ const app = express()
 
 app.get("/", async (req, res, next) => {
   try {
-    const html = await renderLayout({
+    const html = await stitch({
       layout: "templates/mainLayout.pug",
       data: {
         title: "Hello World!",
@@ -247,7 +247,7 @@ block body
 
 ...
 
-const html = await renderLayout({
+const html = await stitch({
   basePath: __dirname,
   layout: 'templates/homeLayout.pug',
   data: {
@@ -285,7 +285,7 @@ html
 ```
 
 ```js
-const html = await renderLayout({
+const html = await stitch({
   layout: "templates/layout.pug",
   blocks: {
     app: App,
@@ -330,7 +330,7 @@ What to do if you have a bunch of old-school Backbone views that you don't want 
 
 ...
 
-const html = await renderLayout({
+const html = await stitch({
   layout: 'templates/loginLayout.pug',
   blocks: {
     app: App
@@ -429,7 +429,7 @@ If you would prefer to use a rendering engine other than React, no problem -- ju
 ```js
 import renderToString from "preact-render-to-string"
 
-const html = await renderLayout({
+const html = await stitch({
   layout: "templates/loginLayout.pug",
   config: {
     componentRenderer: renderToString,
@@ -443,7 +443,7 @@ const html = await renderLayout({
 Additionally, if you would like to override any default template engines (e.g., what is returned by `require('handlebars')`) you can do so by updating `config.engines`:
 
 ```js
-const html = await renderLayout({
+const html = await stitch({
   layout: "templates/loginLayout.pug",
   config: {
     engines: {
@@ -468,7 +468,7 @@ If your React app uses [`styled-components`](https://www.styled-components.com/)
 ```js
 import styled from "styled-components"
 
-const html = await renderLayout({
+const html = await stitch({
   layout: "templates/layout.pug",
   config: {
     styledComponents: true,
@@ -503,7 +503,7 @@ html
 ## Full API
 
 ```js
-const html = await renderLayout({
+const html = await stitch({
 
   /**
    * Sets a base path from which to fetch templates.
@@ -613,7 +613,7 @@ const html = await renderLayout({
 All of the examples assume that you've enabled [async / await](https://medium.com/@Abazhenov/using-async-await-in-express-with-node-8-b8af872c0016), which comes by default in versions of Node >= `7.6.0`. If you're getting this error, it's likely you're using an older version that doesn't yet support this feature. But no fear - async / await is just a wrapper around Promises:
 
 ```js
-renderLayout({ layout: "layout.ejs" })
+stitch({ layout: "layout.ejs" })
   .then(html => {
     res.send(html)
   })
@@ -624,7 +624,7 @@ renderLayout({ layout: "layout.ejs" })
 
 > Async / await is supported in my version of Node, but I'm not seeing anything in the browser and no errors in the console!
 
-Did you remember to use the `await` keyword before `renderLayout`? It's easy to forget :)
+Did you remember to use the `await` keyword before `stitch`? It's easy to forget :)
 
 ## Development
 

--- a/examples/1-ejs-hello-world/routes.js
+++ b/examples/1-ejs-hello-world/routes.js
@@ -1,12 +1,12 @@
 import App from './components/App'
 import express from 'express'
-import { renderLayout } from '@artsy/stitch'
+import { stitch } from '@artsy/stitch'
 
 const app = module.exports = express()
 
 app.get('/', async (req, res, next) => {
   try {
-    const layout = await renderLayout({
+    const layout = await stitch({
       layout: 'templates/layout.ejs',
       blocks: {
         head: 'templates/head.ejs',

--- a/examples/2-handlebars-hello-world/routes.js
+++ b/examples/2-handlebars-hello-world/routes.js
@@ -1,12 +1,12 @@
 import App from './components/App'
 import express from 'express'
-import { renderLayout } from '@artsy/stitch'
+import { stitch } from '@artsy/stitch'
 
 const app = module.exports = express()
 
 app.get('/', async (req, res) => {
   try {
-    const layout = await renderLayout({
+    const layout = await stitch({
       layout: 'templates/layout.handlebars',
       blocks: {
         body: App

--- a/examples/3-jade/routes.js
+++ b/examples/3-jade/routes.js
@@ -1,12 +1,12 @@
 import App from './components/App'
 import express from 'express'
-import { renderLayout } from '@artsy/stitch'
+import { stitch } from '@artsy/stitch'
 
 const app = module.exports = express()
 
 app.get('/', async (req, res) => {
   try {
-    const layout = await renderLayout({
+    const layout = await stitch({
       layout: 'templates/layout.jade',
       blocks: {
         head: 'templates/head.jade',

--- a/examples/4-styled-components/routes.js
+++ b/examples/4-styled-components/routes.js
@@ -1,13 +1,13 @@
 import React from 'react'
 import express from 'express'
 import styled from 'styled-components'
-import { renderLayout } from '@artsy/stitch'
+import { stitch } from '@artsy/stitch'
 
 const app = module.exports = express()
 
 app.get('/', async (req, res) => {
   try {
-    const layout = await renderLayout({
+    const layout = await stitch({
       layout: 'templates/layout.ejs',
       config: {
         styledComponents: true

--- a/examples/5-preact-custom-renderer/routes.js
+++ b/examples/5-preact-custom-renderer/routes.js
@@ -1,6 +1,6 @@
 import express from 'express'
 import renderToString from 'preact-render-to-string'
-import { renderLayout } from '@artsy/stitch'
+import { stitch } from '@artsy/stitch'
 import { h } from 'preact'
 /** @jsx h */
 
@@ -8,7 +8,7 @@ const app = module.exports = express()
 
 app.get('/', async (req, res) => {
   try {
-    const layout = await renderLayout({
+    const layout = await stitch({
       layout: 'templates/layout.ejs',
       config: {
         componentRenderer: renderToString

--- a/examples/6-isomorphic-react-styled-components-backbone-pug-webpack/apps/backbone/index.js
+++ b/examples/6-isomorphic-react-styled-components-backbone-pug-webpack/apps/backbone/index.js
@@ -1,12 +1,12 @@
 import App from './components/App'
 import express from 'express'
-import { renderLayout } from '@artsy/stitch'
+import { stitch } from '@artsy/stitch'
 
 const app = module.exports = express()
 
 app.get('/backbone', async (req, res, next) => {
   try {
-    const layout = await renderLayout({
+    const layout = await stitch({
       basePath: __dirname,
       layout: 'templates/layout.pug',
       blocks: {

--- a/examples/6-isomorphic-react-styled-components-backbone-pug-webpack/apps/home/index.js
+++ b/examples/6-isomorphic-react-styled-components-backbone-pug-webpack/apps/home/index.js
@@ -1,13 +1,13 @@
 import App from './components/App'
 import express from 'express'
-import { renderLayout } from '@artsy/stitch'
+import { stitch } from '@artsy/stitch'
 
 const app = module.exports = express()
 
 const routes = {
   async index (req, res) {
     try {
-      const layout = await renderLayout({
+      const layout = await stitch({
         basePath: __dirname,
         layout: 'templates/layout.pug',
         blocks: {

--- a/examples/6-isomorphic-react-styled-components-backbone-pug-webpack/apps/styled-components/index.js
+++ b/examples/6-isomorphic-react-styled-components-backbone-pug-webpack/apps/styled-components/index.js
@@ -1,12 +1,12 @@
 import App from './components/App'
 import express from 'express'
-import { renderLayout } from '@artsy/stitch'
+import { stitch } from '@artsy/stitch'
 
 const app = module.exports = express()
 
 app.get('/styled-components', async (req, res, next) => {
   try {
-    const layout = await renderLayout({
+    const layout = await stitch({
       basePath: __dirname,
       layout: 'templates/layout.pug',
       config: {

--- a/src/__tests__/render.test.js
+++ b/src/__tests__/render.test.js
@@ -3,7 +3,7 @@ import path from "path"
 import { render } from "../render"
 import { keys } from "lodash"
 
-describe("lib/render", () => {
+describe("src/render", () => {
   it("throws if `asset` is not a string or an object", async () => {
     console.error = jest.fn()
     await expect(render()).rejects.toBeDefined()

--- a/src/__tests__/renderSwitch.test.js
+++ b/src/__tests__/renderSwitch.test.js
@@ -2,7 +2,7 @@ import React from "react"
 import path from "path"
 import { renderSwitch } from "../renderSwitch"
 
-describe("lib/renderSwitch", () => {
+describe("src/renderSwitch", () => {
   it("returns a blank string if a block is not provided", async () => {
     const { html } = await renderSwitch(undefined)
     expect(html).toEqual("")

--- a/src/__tests__/renderTemplate.test.js
+++ b/src/__tests__/renderTemplate.test.js
@@ -1,7 +1,7 @@
 import path from "path"
 import { renderTemplate } from "../renderTemplate"
 
-describe("lib/renderTemplate", () => {
+describe("src/renderTemplate", () => {
   it("renders a single template if template is not an array", async () => {
     const title = "hey"
 

--- a/src/__tests__/stitch.test.js
+++ b/src/__tests__/stitch.test.js
@@ -1,9 +1,9 @@
 import React from "react"
 import path from "path"
 import { keys, merge, omit } from "lodash"
-import { renderLayout } from "../"
+import { stitch } from "../"
 
-describe("lib/renderLayout", () => {
+describe("src/stitch", () => {
   const config = (options = {}) => {
     return merge(
       {
@@ -22,20 +22,20 @@ describe("lib/renderLayout", () => {
     )
   }
 
-  describe("#renderLayout", () => {
+  describe("#stitch", () => {
     it("throws if no layout file is provided", async () => {
       console.error = jest.fn()
-      await expect(renderLayout(omit(config(), "layout"))).rejects.toBeDefined()
+      await expect(stitch(omit(config(), "layout"))).rejects.toBeDefined()
     })
 
     it("returns rendered html", async () => {
-      const html = await renderLayout(config())
+      const html = await stitch(config())
       expect(typeof html).toEqual("string")
       expect(html).toMatch("Basic Example")
     })
 
     it("accepts a `basePath` for modifying root file locations", async () => {
-      const html = await renderLayout(
+      const html = await stitch(
         config({
           basePath: __dirname,
           layout: "fixtures/templates/layout.ejs",
@@ -51,7 +51,7 @@ describe("lib/renderLayout", () => {
     it("accepts a `locals` object for local express data", async () => {
       const name = "Hello how are you"
 
-      const html = await renderLayout(
+      const html = await stitch(
         config({
           locals: {
             name,
@@ -65,7 +65,7 @@ describe("lib/renderLayout", () => {
     it("accepts a `data` object for component / app data", async () => {
       const name = "Hello how are you"
 
-      const html = await renderLayout(
+      const html = await stitch(
         config({
           data: {
             name,
@@ -87,7 +87,7 @@ describe("lib/renderLayout", () => {
       const jadeProp = "Lets render a .jade template"
 
       it("can be a path to a template", async () => {
-        const html = await renderLayout(
+        const html = await stitch(
           config({
             blocks: {
               body: "templates/body.jade",
@@ -102,7 +102,7 @@ describe("lib/renderLayout", () => {
       })
 
       it("can be a React component", async () => {
-        const html = await renderLayout(
+        const html = await stitch(
           config({
             blocks: {
               body: props => {
@@ -121,7 +121,7 @@ describe("lib/renderLayout", () => {
 
       it("throws if none of the above", async () => {
         await expect(
-          renderLayout(
+          stitch(
             config({
               blocks: {
                 foo: [],
@@ -136,7 +136,7 @@ describe("lib/renderLayout", () => {
 
     describe("accepts a `templates` object", () => {
       it("can be a path to a template", async () => {
-        const html = await renderLayout(
+        const html = await stitch(
           config({
             blocks: {
               body: props => {
@@ -165,7 +165,7 @@ describe("lib/renderLayout", () => {
       })
 
       it("can be a React component", async () => {
-        const html = await renderLayout(
+        const html = await stitch(
           config({
             blocks: {
               body: props => {
@@ -193,7 +193,7 @@ describe("lib/renderLayout", () => {
 
       it("throws if none of the above", async () => {
         await expect(
-          renderLayout(
+          stitch(
             config({
               templates: {
                 foo: [],
@@ -204,7 +204,7 @@ describe("lib/renderLayout", () => {
       })
 
       it("returns a `templates` object containing rendered html by key", async done => {
-        await renderLayout(
+        await stitch(
           config({
             blocks: {
               body: ({ templates }) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,4 @@
 import { Block } from "./render"
-import { renderLayout as _renderLayout } from "./renderLayout"
 
 export interface StitchConfig {
   /** Custom renderToString-like component renderer */
@@ -44,5 +43,4 @@ export interface StitchOptions {
   }
 }
 
-export const renderLayout = _renderLayout
-export const stitch = _renderLayout
+export { stitch } from "./stitch"

--- a/src/stitch.tsx
+++ b/src/stitch.tsx
@@ -2,7 +2,7 @@ import ReactDOM from "react-dom/server"
 import { StitchOptions } from "./index"
 import { render } from "./render"
 
-export async function renderLayout(options: StitchOptions) {
+export async function stitch(options: StitchOptions) {
   const {
     layout,
     blocks = {},
@@ -18,7 +18,7 @@ export async function renderLayout(options: StitchOptions) {
 
   if (!layout) {
     throw new Error(
-      "(@artsy/stitch: lib/renderLayout) " +
+      "(@artsy/stitch: lib/stitch) " +
         "Error rendering layout: A `layout` file is required."
     )
   }


### PR DESCRIPTION
Follow up to 2.0.0 release. 