### PR TITLE
Fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,59 +1,34 @@
 version: 2.1
 
 orbs:
-  node: artsy/node@0.1.0
   yarn: artsy/yarn@0.1.0
-
-jobs:
-  lint:
-    executor: node/build
-    steps:
-      - yarn/setup
-      - run: yarn lint
-  type-check:
-    executor: node/build
-    steps:
-      - yarn/setup
-      - run: yarn type-check
-  deploy:
-    executor: node/build
-    steps:
-      - add_ssh_keys
-      - yarn/setup
-      # Setup the .npmrc with the proper registry and auth token to publish
-      - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-      - run: yarn release
-  test:
-    executor: node/build
-    steps:
-      - yarn/setup
-      # Runs jest tests with 6 concurrent workers. Without limiting it to 6
-      # workers Jest will spawn many memory hungry workers and ultimately
-      # starve the job for memory.
-      - run: yarn test -w 6
-  update-cache:
-    executor: node/build
-    steps:
-      - yarn/update_dependencies
 
 workflows:
   build_and_verify:
     jobs:
-      - update-cache
-      - lint
-      - type-check
-      - test
-      - deploy:
+      - yarn/workflow-queue
+      - yarn/update-cache:
+          requires:
+            - yarn/workflow-queue
+      - yarn/lint:
+          requires:
+            - yarn/workflow-queue
+      - yarn/type-check:
+          requires:
+            - yarn/workflow-queue
+      - yarn/test:
+          requires:
+            - yarn/workflow-queue
+      - yarn/auto-release:
           # The deploy job is the _only_ job that should have access to our npm
           # tokens. We include a context that has our publish credentials
           # explicitly in this step. https://circleci.com/docs/2.0/contexts/
           context: npm-deploy
           filters:
             branches:
-              only:
-                - master
+              only: master
           requires:
-            - test
-            - lint
-            - type-check
-            - update-cache
+            - yarn/test
+            - yarn/lint
+            - yarn/type-check
+            - yarn/update-cache


### PR DESCRIPTION
Auto-release now relies on the yarn orb so I ported over palette's config here. This is also the new shortened version.