### PR TITLE
Update renovate to have stitch ignore itself

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,9 @@
   "extends": [
     "@artsy:lib"
   ],
+  "ignoreDeps": [
+    "@artsy/stitch"
+  ],
   "reviewers": [
     "damassi"
   ],


### PR DESCRIPTION
Have renovate ignore any updates of stitch inside itself. 