### PR TITLE
Let consolidate cache templates.

### DIFF
--- a/src/__tests__/renderTemplate.test.js
+++ b/src/__tests__/renderTemplate.test.js
@@ -1,5 +1,6 @@
 import path from "path"
 import { renderTemplate } from "../renderTemplate"
+import consolidate from "consolidate"
 
 describe("src/renderTemplate", () => {
   it("renders a single template if template is not an array", async () => {
@@ -66,5 +67,24 @@ describe("src/renderTemplate", () => {
     })
 
     expect(html).toMatch(output({ name, description }))
+  })
+
+  it("tells the underlying render engine to cache", async () => {
+    const _jade = consolidate.jade
+    consolidate.jade = jest.fn()
+    try {
+      await renderTemplate(["templates/body.jade"], {
+        basePath: path.join(__dirname, "fixtures"),
+        locals: {
+          jadeProp: "Be cached",
+        },
+      })
+      expect(consolidate.jade).toHaveBeenLastCalledWith(
+        expect.any(String),
+        expect.objectContaining({ cache: true })
+      )
+    } finally {
+      consolidate.jade = _jade
+    }
   })
 })

--- a/src/renderTemplate.tsx
+++ b/src/renderTemplate.tsx
@@ -30,7 +30,10 @@ export async function renderTemplate(
 
     // Consolidate mutates the `locals` input, so provide a copy or otherwise an
     // empty object if not locals were specified.
-    const html = await compileFn(absoluteFilePath, { ...options.locals })
+    const html = await compileFn(absoluteFilePath, {
+      ...options.locals,
+      cache: true,
+    })
 
     return html
   }


### PR DESCRIPTION
Closes https://artsyproduct.atlassian.net/browse/PLATFORM-1845

Currently it appears that Force is parsing templates on each request.

### BEFORE

Median benchmarking of Artwork page: 3210ms

<img width="1588" alt="before-single-request" src="https://user-images.githubusercontent.com/2320/66428950-543de280-ea17-11e9-8c25-920ae72d7194.png">

### AFTER

Median benchmarking of Artwork page: 2758ms

<img width="1588" alt="after-single-request" src="https://user-images.githubusercontent.com/2320/66428967-5b64f080-ea17-11e9-8ef0-8da0aed25466.png">
