### PR TITLE
fix: setTimeout

### DIFF
--- a/src/internal/clientRenderer.tsx
+++ b/src/internal/clientRenderer.tsx
@@ -13,7 +13,7 @@ export function clientRenderer({
   const components = Object.entries(modules).reduce(
     (moduleMap, [moduleName, Module]: any[]) => {
       const Component = (props: Partial<SerializableComponent> = {}) => {
-        setImmediate(() => {
+        setTimeout(() => {
           if (!props.mountId) {
             console.error(
               "[@artsy/stitch] Error mounting clientside component: `mountId` is " +
@@ -37,7 +37,7 @@ export function clientRenderer({
             </Wrapper>,
             mountPoint
           )
-        })
+        }, 0)
       }
 
       return {


### PR DESCRIPTION
This change is very minor: `setTimeout(..., 0)` and `setImmediate()` are
nearly identical in timing. However `setImmediate` is not a browser-safe
function and must be manually polyfilled with Webpack 5. There is no
need for this polyfill as `setTimeout(..., 0)` works for our usage here.